### PR TITLE
Moved content type validation for service after the response code check

### DIFF
--- a/lib/sword2ruby/service.rb
+++ b/lib/sword2ruby/service.rb
@@ -45,9 +45,11 @@ module Sword2Ruby
       rxml = nil
 
       res = connection.get(base, "Accept" => "application/atomsvc+xml")
-      res.validate_content_type(["application/atomsvc+xml"])
+     
       
       if res.is_a? Net::HTTPSuccess
+        res.validate_content_type(["application/atomsvc+xml"])
+        
         service = self.class.parse(res.body, base, self)
 
         #Update workspaces, collections and their feeds to use the Service's http connection


### PR DESCRIPTION
When I connect to Dspace with an invalid username and password it returns 403 forbidden. The AtomService file tried to validate content type before it knew if the user logged in successfully or not.  So I just moved the validate_content_type after the if statement checking if the connection returned 200. 

I kept on getting Atom::WrongMimetype errors, so that seemed a bit weird. Hope you can merge that into the Gem as well.
