### PR TITLE
Bug fixes for interoperability with the Java SWORD Server

### DIFF
--- a/lib/sword2ruby/collection.rb
+++ b/lib/sword2ruby/collection.rb
@@ -24,7 +24,7 @@ module Sword2Ruby
     #This method returns the string value of the <sword:collectionPolicy>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument],
     #or nil if it is not defined in the service document.
     def sword_collection_policy
-      Utility.find_element_text(extensions, "sword:collectionPolicy")
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "collectionPolicy").text
     end
 
     #This method returns the boolean value of the <sword:mediation>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tag,
@@ -36,19 +36,19 @@ module Sword2Ruby
     #This method returns the string value of the <sword:treatment>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tag,
     #or nil if it is not defined in the service document.
     def sword_treatment
-      Utility.find_element_text(extensions, "sword:treatment")
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "treatment").text
     end
     
     #This method returns an array of the string values of the <sword:acceptPackaging>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tags,
     #or an empty array [ ] if none are defined in the service document.
     def sword_accept_packagings
-      Utility.find_elements_text(extensions, "sword:acceptPackaging")
+      Utility.find_elements_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "acceptPackaging")
     end
 
     #This method returns an array of the string values of the <sword:service>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tags,
     #or an empty array [ ] if none are defined in the service document.
     def sword_services
-      Utility.find_elements_text(extensions, "sword:service")
+      Utility.find_elements_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "service")
     end
 
     #This method returns the string value of the <app:accept>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tag,

--- a/lib/sword2ruby/collection.rb
+++ b/lib/sword2ruby/collection.rb
@@ -24,7 +24,7 @@ module Sword2Ruby
     #This method returns the string value of the <sword:collectionPolicy>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument],
     #or nil if it is not defined in the service document.
     def sword_collection_policy
-      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "collectionPolicy").text
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "collectionPolicy")
     end
 
     #This method returns the boolean value of the <sword:mediation>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tag,
@@ -36,7 +36,7 @@ module Sword2Ruby
     #This method returns the string value of the <sword:treatment>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tag,
     #or nil if it is not defined in the service document.
     def sword_treatment
-      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "treatment").text
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "treatment")
     end
     
     #This method returns an array of the string values of the <sword:acceptPackaging>[http://sword-app.svn.sourceforge.net/viewvc/sword-app/spec/tags/sword-2.0/SWORDProfile.html?revision=377#protocoloperations_retreivingservicedocument] tags,

--- a/lib/sword2ruby/collection.rb
+++ b/lib/sword2ruby/collection.rb
@@ -239,6 +239,7 @@ module Sword2Ruby
       tmp << "Content-Type: #{options[:content_type]}\r\n"
       tmp << "Content-Disposition: attachment; name=payload; filename=#{filename}\r\n"
       tmp << "Content-MD5: #{md5}\r\n"
+      tmp << "Content-Transfer-Encoding: base64\r\n"
       tmp << "Packaging: #{options[:packaging]}\r\n" if options[:packaging]
       tmp << "MIME-Version: 1.0\r\n\r\n"
       

--- a/lib/sword2ruby/connection.rb
+++ b/lib/sword2ruby/connection.rb
@@ -33,5 +33,24 @@ module Sword2Ruby
       
     end #initialize
 
+    def get(url, headers = {})
+      headers.merge!({ 'On-Behalf-Of' => @user_credentials.on_behalf_of}) if @user_credentials.on_behalf_of
+      super(url, headers)
+    end
+
+    def post(url, body, headers = {})
+      headers.merge!({ 'On-Behalf-Of' => @user_credentials.on_behalf_of}) if @user_credentials.on_behalf_of
+      super(url, body, headers)
+    end
+
+    def put(url, body, headers = {})
+      headers.merge!({ 'On-Behalf-Of' => @user_credentials.on_behalf_of}) if @user_credentials.on_behalf_of
+      super(url, body, headers)
+    end    
+
+    def delete(url, body = nil, headers = {})
+      headers.merge!({ 'On-Behalf-Of' => @user_credentials.on_behalf_of}) if @user_credentials.on_behalf_of
+      super(url, body, headers)
+    end
   end  #class
 end #module

--- a/lib/sword2ruby/entry.rb
+++ b/lib/sword2ruby/entry.rb
@@ -56,19 +56,19 @@ module Sword2Ruby
     #This method returns an array of string values for the <b>sword packagings</b>, from the <sword:packaging> tags (usually contained in the DepositReceipt Entry),
     #or an empty array [ ] if none are defined.
     def sword_packagings
-      Utility.find_elements_text(extensions, "sword:packaging")
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "packaging")
     end
     
     #This method returns the string value of the <b>sword treatment</b> <sword:treatment> tag (usually contained in the DepositReceipt Entry),
     #or nil if it is not defined.
     def sword_treatment
-      Utility.find_element_text(extensions, "sword:treatment")
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "treatment")
     end
 
     #This method returns the string value of the <b>sword verbose description</b> <sword:verboseDescription> tag (usually contained in the DepositReceipt Entry),
     #or nil if it is not defined.    
     def sword_verbose_description
-      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "verboseDescription").text
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "verboseDescription")
     end
 
     #This method returns an array of the Dublin Core elements (usually contained in the DepositReceipt Entry),

--- a/lib/sword2ruby/entry.rb
+++ b/lib/sword2ruby/entry.rb
@@ -68,7 +68,7 @@ module Sword2Ruby
     #This method returns the string value of the <b>sword verbose description</b> <sword:verboseDescription> tag (usually contained in the DepositReceipt Entry),
     #or nil if it is not defined.    
     def sword_verbose_description
-      Utility.find_element_text(extensions, "sword:verboseDescription")
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/net/sword/terms/", "verboseDescription").text
     end
 
     #This method returns an array of the Dublin Core elements (usually contained in the DepositReceipt Entry),
@@ -77,6 +77,10 @@ module Sword2Ruby
     #For more information, see the {Dublin Core Metadata Terms specification}[http://dublincore.org/documents/dcmi-terms/].
     def dublin_core_extensions
       Utility.find_elements_by_namespace(extensions, "http://purl.org/dc/terms/")
+    end
+
+    def dublin_core_extension(name)
+      Utility.find_element_by_namespace_and_name(extensions, "http://purl.org/dc/terms/", name)
     end
 
     #This method adds a new Dublin Core element to the entry,

--- a/lib/sword2ruby/service.rb
+++ b/lib/sword2ruby/service.rb
@@ -48,7 +48,7 @@ module Sword2Ruby
      
       
       if res.is_a? Net::HTTPSuccess
-        res.validate_content_type(["application/atomsvc+xml"])
+        res.validate_content_type(["application/atomsvc+xml", "application/atomserv+xml"])
         
         service = self.class.parse(res.body, base, self)
 

--- a/lib/sword2ruby/utility.rb
+++ b/lib/sword2ruby/utility.rb
@@ -110,7 +110,7 @@ module Sword2Ruby
     #name:: the expanded name of the element(s) to search for
     #It will return the first element found with a matching namespace and name, othewise nil.    
     def self.find_element_by_namespace_and_name(elements, namespace, name)
-        elements.find {|e| e.namespace == namespace && e.fully_expanded_name == name}
+        elements.find {|e| e.namespace == namespace && e.fully_expanded_name == name}.text rescue nil
     end    
 
     #Method to return the text value of first Atom::Element found in an array of Atom::Elements by its name.

--- a/lib/sword2ruby/utility.rb
+++ b/lib/sword2ruby/utility.rb
@@ -103,6 +103,16 @@ module Sword2Ruby
       elements.find(NIL_LAMBDA) {|e| e.fully_expanded_name == name}
     end
 
+    #Method to return the text value of first Atom::Elements found in an array of Atom::Elements by its namespace and name.
+    #===Parameters
+    #elements:: an array of Atom::Elements
+    #namespace:: the namespace to search for, e.g. "http://purl.org/dc/terms/"
+    #name:: the expanded name of the element(s) to search for
+    #It will return the first element found with a matching namespace and name, othewise nil.    
+    def self.find_element_by_namespace_and_name(elements, namespace, name)
+        elements.find {|e| e.namespace == namespace && e.fully_expanded_name == name}
+    end    
+
     #Method to return the text value of first Atom::Element found in an array of Atom::Elements by its name.
     #===Parameters
     #elements:: an array of Atom::Elements
@@ -181,6 +191,16 @@ module Sword2Ruby
       elements.find_all {|e| e.fully_expanded_name==name}.collect {|e| e.text}
     end
 
+    #Method to return an array of matching Atom::Elements found in an array of Atom::Elements by its namespace and name.
+    #===Parameters
+    #elements:: an array of Atom::Elements
+    #namespace:: the namespace to search for, e.g. "http://purl.org/dc/terms/"
+    #name:: the expanded name of the element(s) to search for
+    #It will return the first element found with a matching namespace and name, othewise nil.    
+    def self.find_elements_by_namespace_and_name(elements, namespace, name)
+        elements.find_all {|e| e.namespace == namespace && e.fully_expanded_name == name}.collect {|e| e.text}
+    end    
+
     #Method to return an array of attribute values of matching Atom::Elements found in an array of Atom::Elements by their name.
     #===Parameters
     #elements:: an array of Atom::Elements
@@ -199,17 +219,6 @@ module Sword2Ruby
     def self.find_elements_by_namespace(elements, namespace)
       elements.find_all {|e| e.namespace == namespace}
     end
-
-    #Method to return the first matching Atom::Elements found in an array of Atom::Elements by its namespace and name.
-    #===Parameters
-    #elements:: an array of Atom::Elements
-    #namespace:: the namespace to search for, e.g. "http://purl.org/dc/terms/"
-    #name:: the expanded name of the element(s) to search for
-    #It will return the first element found with a matching namespace and name, othewise nil.    
-    def self.find_element_by_namespace_and_name(elements, namespace, name)
-        elements.find {|e| e.namespace == namespace && e.fully_expanded_name == name}
-    end
-    
   
     #Method to return an array of matching Atom::Elements found in an array of Atom::Elements by their namespace.
     #===Parameters

--- a/lib/sword2ruby/utility.rb
+++ b/lib/sword2ruby/utility.rb
@@ -199,6 +199,16 @@ module Sword2Ruby
     def self.find_elements_by_namespace(elements, namespace)
       elements.find_all {|e| e.namespace == namespace}
     end
+
+    #Method to return the first matching Atom::Elements found in an array of Atom::Elements by its namespace and name.
+    #===Parameters
+    #elements:: an array of Atom::Elements
+    #namespace:: the namespace to search for, e.g. "http://purl.org/dc/terms/"
+    #name:: the expanded name of the element(s) to search for
+    #It will return the first element found with a matching namespace and name, othewise nil.    
+    def self.find_element_by_namespace_and_name(elements, namespace, name)
+        elements.find {|e| e.namespace == namespace && e.fully_expanded_name == name}
+    end
     
   
     #Method to return an array of matching Atom::Elements found in an array of Atom::Elements by their namespace.
@@ -216,7 +226,7 @@ module Sword2Ruby
     #Returns an array of the form [filename, md5_digest, data]
     def self.read_file(filepath) 
       data = nil
-      File.open(filepath,'r') do |file|
+      File.open(filepath,'rb') do |file|
         data = file.gets(nil) #Read entire file, no Base64.encode64()
       end #file is closed automatically
       return [File.basename(filepath), Digest::MD5.hexdigest(data), data]

--- a/lib/sword2ruby/version.rb
+++ b/lib/sword2ruby/version.rb
@@ -1,4 +1,4 @@
 module Sword2Ruby
   #The version of the Sword2Ruby library
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
Hi there. We’ve been working with this library in order to interoperate with Ex Libris Alma which now supports SWORD for digital deposits. There are a couple of bug fixes that we’d love to merge, if you’re interested:

1. On-Behalf-Of not propagated from sword_user to connection
2. Some elements (such as sword_verbose_description) assume namespace prefix rather than
selecting by namespace
3. Statement doesn't accept application/atomserv+xml as specified by
standard
4. Files are read in text mode rather than binary; required for Windows
5. Add Content-Transfer-Encoding header for multipart deposits

Thanks.