### PR TITLE
Add XML Prolog to the entry XML so DSpace recognizes the charset as UTF-8

### DIFF
--- a/lib/sword2ruby/entry.rb
+++ b/lib/sword2ruby/entry.rb
@@ -8,7 +8,7 @@ module Sword2Ruby
   class ::Atom::Entry < ::Atom::Element
     
     def to_s
-      return "<?xml version='1.0' encoding='UTF-8'?>" + super.to_s
+      return '<?xml version="1.0" encoding="UTF-8"?>' + super.to_s
     end
 
 #Deposit Receipt tags

--- a/lib/sword2ruby/entry.rb
+++ b/lib/sword2ruby/entry.rb
@@ -6,6 +6,10 @@ module Sword2Ruby
   #
   #Please see the {atom-tools documentation}[http://rdoc.info/github/bct/atom-tools/master/frames] for a complete list of attributes and methods.
   class ::Atom::Entry < ::Atom::Element
+    
+    def to_s
+      return "<?xml version='1.0' encoding='UTF-8'?>" + super.to_s
+    end
 
 #Deposit Receipt tags
     


### PR DESCRIPTION
There was a problem with diacritics when deposit to DSpace, it turned out that sword2ruby gem, entry.rb, does NOT output the XML prolog, so DSpace does not treat the XML as UTF-8 and diacritics are lost.

I overrided the to_s method in entry.rb to add the XML prolog